### PR TITLE
Add alpha channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,10 @@ cd 90cube_grid_OPS_resampler
 ```
 
 ### **2️⃣ 가상환경 생성 및 패키지 설치**
-Windows의 경우:
-```bash
-install.bat
-```
-Mac/Linux의 경우:
+가상환경을 생성하고 패키지를 설치합니다:
 ```bash
 python -m venv venv
-source venv/bin/activate
+source venv/bin/activate  # Windows는 venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
@@ -45,25 +41,21 @@ pip install -r requirements.txt
 
 ## **📌 실행 방법**
 ### **1️⃣ Gradio 웹 UI 실행**
+가상환경을 활성화한 뒤 아래 명령으로 실행합니다:
 ```bash
-start.bat
-```
-✅ 실행하면 **자동으로 웹 브라우저가 열림**  
-✅ UI에서 **이미지 업로드 → `OPS` 값 설정 → 미리보기 → 변환 결과 다운로드 가능!**  
-
-### **2️⃣ 터미널에서 수동 실행**
-```bash
-call venv\Scripts\activate
 python app.py
 ```
+✅ 실행하면 **자동으로 웹 브라우저가 열림**
+✅ UI에서 **이미지 업로드 → `OPS` 값 설정 → 미리보기 → 변환 결과 다운로드 가능!**
 
 ---
 
 ## **📌 주요 기능**
-✅ **정사각형 픽셀 유지** → 픽셀아트의 품질을 유지하면서 변환  
-✅ **OPS 값 조절 (0.5~10, 소수 가능)** → 더 정밀한 크기 조정 가능  
-✅ **Gradio 기반 웹 UI 제공** → 간편한 이미지 업로드 & 변환  
-✅ **변환된 결과 미리보기 가능** → 다운로드 전에 픽셀아트 확인  
+✅ **정사각형 픽셀 유지** → 픽셀아트의 품질을 유지하면서 변환
+✅ **OPS 값 조절 (0.5~10, 소수 가능)** → 더 정밀한 크기 조정 가능
+✅ **Gradio 기반 웹 UI 제공** → 간편한 이미지 업로드 & 변환
+✅ **변환된 결과 미리보기 가능** → 다운로드 전에 픽셀아트 확인
+✅ **알파 채널(투명도) 보존** → PNG 이미지의 투명도가 유지됨
 
 ---
 
@@ -76,13 +68,17 @@ python app.py
 │   │── grid_sampler.py  # 픽셀 변환 (그리드 기반 변환)
 │   │── image_loader.py  # 이미지 로드 & 저장 처리
 │── app.py               # Gradio 웹 UI 실행 파일
-│── install.bat          # 가상환경 생성 & 패키지 설치 자동화
-│── start.bat            # 가상환경 활성화 & Gradio 실행
 │── requirements.txt     # 필수 패키지 목록
 │── README.md            # 프로젝트 설명서
+```
+
+## **📌 테스트 실행**
+`pytest`를 이용해 기본 동작을 확인할 수 있습니다:
+```bash
+pytest
 ```
 
 ---
 
 
-🚀 **더 많은 기능이 필요하면 언제든지 피드백 주세요!**  
+🚀 **더 많은 기능이 필요하면 언제든지 피드백 주세요!**

--- a/app.py
+++ b/app.py
@@ -14,14 +14,24 @@ os.makedirs("input", exist_ok=True)
 os.makedirs("output", exist_ok=True)
 
 def process_image(image, one_pixel_size):
-    """ Gradio에서 업로드된 이미지를 처리하여 변환 """
-    image = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)  # OpenCV로 변환
-    resized_img = create_resized_grid(image, one_pixel_size)  # ✅ 기존 grid_sampler.py의 함수 사용
-    
+    """Gradio에서 업로드된 이미지를 처리하여 변환합니다."""
+    np_image = np.array(image)
+    if np_image.shape[2] == 4:
+        cv_image = cv2.cvtColor(np_image, cv2.COLOR_RGBA2BGRA)
+    else:
+        cv_image = cv2.cvtColor(np_image, cv2.COLOR_RGB2BGR)
+
+    resized_img = create_resized_grid(cv_image, one_pixel_size)
+
     output_path = "output/gradio_result.png"
-    save_image(resized_img, output_path)  # 결과 저장
-    
-    return resized_img, output_path  # 변환된 이미지 미리보기 및 다운로드 가능하도록 반환
+    save_image(resized_img, output_path)
+
+    if resized_img.shape[2] == 4:
+        preview = cv2.cvtColor(resized_img, cv2.COLOR_BGRA2RGBA)
+    else:
+        preview = cv2.cvtColor(resized_img, cv2.COLOR_BGR2RGB)
+
+    return preview, output_path
 
 # Gradio UI 생성
 iface = gr.Interface(

--- a/src/grid_sampler.py
+++ b/src/grid_sampler.py
@@ -2,21 +2,29 @@ import cv2
 import numpy as np
 
 def create_resized_grid(image, one_pixel_size):
+    """이미지 크기를 변경하되 정사각형 픽셀을 유지합니다.
+
+    Parameters
+    ----------
+    image : ``numpy.ndarray``
+        BGR(A) 형식의 이미지 배열로 3채널 또는 4채널을 모두 지원합니다.
+    one_pixel_size : float
+        출력 이미지에서 한 픽셀이 원본에서 차지하는 크기입니다.
     """
-    1. 원본 이미지의 크기를 감지하고, 이를 픽셀 블록으로 해석
-    2. one_pixel_size를 기준으로 새로운 픽셀아트 생성 (정사각형 유지)
-    """
-    original_height, original_width, _ = image.shape
+    original_height, original_width, channels = image.shape
     
     # 새로운 그리드 크기 계산 (one_pixel_size를 이용해 정사각형 유지)
-    target_width = round(original_width / one_pixel_size)
-    target_height = round(original_height / one_pixel_size)
+    if one_pixel_size <= 0:
+        raise ValueError("one_pixel_size must be greater than 0")
+
+    target_width = max(1, round(original_width / one_pixel_size))
+    target_height = max(1, round(original_height / one_pixel_size))
     
     # 정사각형 유지 보정 (block_x == block_y 강제)
     block_size = (original_width / target_width + original_height / target_height) / 2
     
     # 새로운 이미지 생성 (초기화)
-    new_image = np.zeros((target_height, target_width, 3), dtype=np.uint8)
+    new_image = np.zeros((target_height, target_width, channels), dtype=np.uint8)
     
     for i in range(target_height):
         for j in range(target_width):

--- a/tests/test_grid_sampler.py
+++ b/tests/test_grid_sampler.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from grid_sampler import create_resized_grid
+
+
+def test_large_one_pixel_size():
+    img = np.zeros((5, 5, 3), dtype=np.uint8)
+    # one_pixel_size larger than image dimensions should still return 1x1 image
+    out = create_resized_grid(img, 10)
+    assert out.shape[:2] == (1, 1)
+
+
+def test_invalid_one_pixel_size():
+    img = np.zeros((5, 5, 3), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        create_resized_grid(img, 0)
+
+
+def test_alpha_channel_preserved():
+    img = np.zeros((4, 4, 4), dtype=np.uint8)
+    img[:, :, 3] = 128
+    out = create_resized_grid(img, 2)
+    assert out.shape[2] == 4
+    assert np.all(out[:, :, 3] == 128)


### PR DESCRIPTION
## Summary
- keep transparency by supporting RGBA images throughout the pipeline
- document alpha channel support in README
- test RGBA behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d4499268832d91efa0afba6b4b6f